### PR TITLE
dev

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -160,13 +160,14 @@ DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 # resframework 
 
-# REST_FRAMEWORK = {
-#     'DEFAULT_AUTHENTICATION_CLASSES': (
-#         'rest_framework.authentication.TokenAuthentication',
-#     ),
+REST_FRAMEWORK = {
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework.authentication.TokenAuthentication',
+    ),
 
-#     'DEFAULT_RENDERER_CLASSES': [
-#         'rest_framework.renderers.JSONRenderer',
-#         'rest_framework.renderers.BrowsableAPIRenderer',
-#     ]
-# }
+    'DEFAULT_RENDERER_CLASSES': [
+        'rest_framework.renderers.JSONRenderer',
+        'rest_framework.renderers.BrowsableAPIRenderer',
+    ]
+}
+


### PR DESCRIPTION
The error message "For 'properties/body', {} is not a string" typically occurs when the OpenAI API expects a string value but receives an object instead. To resolve this issue, you need to ensure that you pass a string value for the prompt or any other parameter that requires a string.

Here's an example of how you can use the openai package in Node.js to generate text using the complete method: